### PR TITLE
Mohsen / fixed modal size on mobile devices

### DIFF
--- a/src/components/core/modal/components/modal-content-container.tsx
+++ b/src/components/core/modal/components/modal-content-container.tsx
@@ -10,7 +10,6 @@ const ModalContentContainer = styled(PrimitiveContent, {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    maxWidth: '90vw',
     padding: '0px',
 
     '@media (prefers-reduced-motion: no-preference)': {
@@ -45,7 +44,14 @@ const ModalContentContainer = styled(PrimitiveContent, {
                     width: '328px',
                 },
             },
-            page: {},
+            page: {
+                display: 'flex',
+                flexDirection: 'column',
+                '@mobile': {
+                    width: '100%',
+                    height: '100%',
+                },
+            },
         },
     },
     defaultVariants: {

--- a/src/components/core/modal/components/page-content.tsx
+++ b/src/components/core/modal/components/page-content.tsx
@@ -4,7 +4,11 @@ import { TPageContentProps } from '../types';
 import ModalContentContainer from './modal-content-container';
 import ModalFooterContainer from './modal-footer-container';
 import TextTitle from './text-title';
+import { styled } from 'Styles/stitches.config';
 
+const ContentContainer = styled('div', {
+    flex: 1,
+});
 const PageContent = forwardRef<HTMLDivElement, TPageContentProps>(
     (
         {
@@ -40,7 +44,7 @@ const PageContent = forwardRef<HTMLDivElement, TPageContentProps>(
                 <TextTitle type={'page'} has_close_button={has_close_button} has_title_separator={has_title_separator}>
                     {title}
                 </TextTitle>
-                {children}
+                <ContentContainer>{children}</ContentContainer>
                 <ModalFooterContainer
                     block_action_buttons={block_action_buttons}
                     action_buttons={action_buttons}

--- a/src/components/core/modal/stories/page-modal.stories.tsx
+++ b/src/components/core/modal/stories/page-modal.stories.tsx
@@ -57,7 +57,7 @@ export default {
 
 const Box = styled('div', {
     width: '30rem',
-    height: '30rem',
+    height: '20rem',
 });
 
 const actionButtons: TModalActionButton[] = [


### PR DESCRIPTION
- based on ZH modal component should be full scren on mobile devices

# Description

Based on Zh we have to set the modal size ( only page type ) fullscreen on mobile devices. 

Addresses (redmine-issue-number)#76224

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update
-   [ ] Package update

# Author Checklist:

Please check relevant items before requesting for review.

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
