### PR TITLE
Bump @deriv/ui from 0.6.0 to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@deriv/ui",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@deriv/ui",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
                 "@radix-ui/react-checkbox": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deriv/ui",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "description": "A UI library developed by Deriv",
     "main": "./dist/cjs/components.js",
     "module": "./dist/es/components.js",


### PR DESCRIPTION
```diff <!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>versions should be min then max</pre>
</body>
</html> ``` Diff url: https://diff.intrinsic.com/@deriv/ui/0.6.0/0.6.0.diff